### PR TITLE
Update Tests and Code to Pester 4

### DIFF
--- a/Other/Full-ModuleTests.txt
+++ b/Other/Full-ModuleTests.txt
@@ -28,14 +28,14 @@ if ($PrivateFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PrivateFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
     
     foreach ($rule in $rules) {
 
                     It “passes the PSScriptAnalyzer Rule $rule“ {
 
-                        (Invoke-ScriptAnalyzer -Path $PrivateFunction.FullName -IncludeRule $rule.RuleName ).Count | Should Be 0
+                        (Invoke-ScriptAnalyzer -Path $PrivateFunction.FullName -IncludeRule $rule.RuleName ).Count | Should -Be 0
 
                     }
                  }
@@ -65,13 +65,13 @@ if ($PublicFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PublicFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
       foreach ($rule in $rules) {
 
                     It “passes the PSScriptAnalyzer Rule $rule“ {
 
-                        (Invoke-ScriptAnalyzer -Path $PublicFunction.FullName -IncludeRule $rule.RuleName ).Count | Should Be 0
+                        (Invoke-ScriptAnalyzer -Path $PublicFunction.FullName -IncludeRule $rule.RuleName ).Count | Should -Be 0
 
                         }
                     }

--- a/Other/Min-ModuleTests.txt
+++ b/Other/Min-ModuleTests.txt
@@ -31,7 +31,7 @@ if ($PrivateFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PrivateFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
     
               
@@ -53,7 +53,7 @@ if ($PublicFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PublicFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
                   
             }
@@ -74,7 +74,7 @@ Describe 'ScriptAnalyzer Rule Testing' {
         Context 'Public Functions' {
 
             It 'Passes the Script Analyzer ' {
-                (Invoke-ScriptAnalyzer -Path $PublicFunctionPath -Recurse ).Count | Should Be 0
+                (Invoke-ScriptAnalyzer -Path $PublicFunctionPath -Recurse ).Count | Should -Be 0
 
                 }
         }
@@ -82,7 +82,7 @@ Describe 'ScriptAnalyzer Rule Testing' {
          Context 'Private Functions' {
 
             It 'Passes the Script Analyzer ' {
-                (Invoke-ScriptAnalyzer -Path $PrivateFunctionPath ).Count | Should Be 0
+                (Invoke-ScriptAnalyzer -Path $PrivateFunctionPath ).Count | Should -Be 0
 
                 }
         }

--- a/Other/Norm-ModuleTests.txt
+++ b/Other/Norm-ModuleTests.txt
@@ -31,7 +31,7 @@ if ($PrivateFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PrivateFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
     
               
@@ -60,7 +60,7 @@ if ($PublicFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PublicFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
                   
             }
@@ -81,7 +81,7 @@ Describe 'ScriptAnalyzer Rule Testing' {
         Context 'Public Functions' {
 
             It 'Passes the Script Analyzer ' {
-                (Invoke-ScriptAnalyzer -Path $PublicFunctionPath -Recurse ).Count | Should Be 0
+                (Invoke-ScriptAnalyzer -Path $PublicFunctionPath -Recurse ).Count | Should -Be 0
 
                 }
         }
@@ -89,7 +89,7 @@ Describe 'ScriptAnalyzer Rule Testing' {
          Context 'Private Functions' {
 
             It 'Passes the Script Analyzer ' {
-                (Invoke-ScriptAnalyzer -Path $PrivateFunctionPath ).Count | Should Be 0
+                (Invoke-ScriptAnalyzer -Path $PrivateFunctionPath ).Count | Should -Be 0
 
                 }
         }

--- a/PesterHelpers.Full.Tests.ps1
+++ b/PesterHelpers.Full.Tests.ps1
@@ -28,14 +28,14 @@ if ($PrivateFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PrivateFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
     
     foreach ($rule in $rules) {
 
                     It “passes the PSScriptAnalyzer Rule $rule“ {
 
-                        (Invoke-ScriptAnalyzer -Path $PrivateFunction.FullName -IncludeRule $rule.RuleName ).Count | Should Be 0
+                        (Invoke-ScriptAnalyzer -Path $PrivateFunction.FullName -IncludeRule $rule.RuleName ).Count | Should -Be 0
 
                     }
                  }
@@ -65,13 +65,13 @@ if ($PublicFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PublicFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
       foreach ($rule in $rules) {
 
                     It “passes the PSScriptAnalyzer Rule $rule“ {
 
-                        (Invoke-ScriptAnalyzer -Path $PublicFunction.FullName -IncludeRule $rule.RuleName ).Count | Should Be 0
+                        (Invoke-ScriptAnalyzer -Path $PublicFunction.FullName -IncludeRule $rule.RuleName ).Count | Should -Be 0
 
                         }
                     }

--- a/PesterHelpers.Min.Tests.ps1
+++ b/PesterHelpers.Min.Tests.ps1
@@ -31,7 +31,7 @@ if ($PrivateFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PrivateFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
     
               
@@ -53,7 +53,7 @@ if ($PublicFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PublicFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
                   
             }
@@ -74,7 +74,7 @@ Describe 'ScriptAnalyzer Rule Testing' {
         Context 'Public Functions' {
 
             It 'Passes the Script Analyzer ' {
-                (Invoke-ScriptAnalyzer -Path $PublicFunctionPath -Recurse ).Count | Should Be 0
+                (Invoke-ScriptAnalyzer -Path $PublicFunctionPath -Recurse ).Count | Should -Be 0
 
                 }
         }
@@ -82,7 +82,7 @@ Describe 'ScriptAnalyzer Rule Testing' {
          Context 'Private Functions' {
 
             It 'Passes the Script Analyzer ' {
-                (Invoke-ScriptAnalyzer -Path $PrivateFunctionPath ).Count | Should Be 0
+                (Invoke-ScriptAnalyzer -Path $PrivateFunctionPath ).Count | Should -Be 0
 
                 }
         }

--- a/PesterHelpers.Norm.Tests.ps1
+++ b/PesterHelpers.Norm.Tests.ps1
@@ -31,7 +31,7 @@ if ($PrivateFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PrivateFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
     
               
@@ -60,7 +60,7 @@ if ($PublicFunctions.count -gt 0) {
                 $contents = Get-Content -Path $PublicFunction.FullName -ErrorAction Stop
                 $errors = $null
                 $null = [System.Management.Automation.PSParser]::Tokenize($contents, [ref]$errors)
-                $errors.Count | Should Be 0
+                $errors.Count | Should -Be 0
             }
                   
             }
@@ -81,7 +81,7 @@ Describe 'ScriptAnalyzer Rule Testing' {
         Context 'Public Functions' {
 
             It 'Passes the Script Analyzer ' {
-                (Invoke-ScriptAnalyzer -Path $PublicFunctionPath -Recurse ).Count | Should Be 0
+                (Invoke-ScriptAnalyzer -Path $PublicFunctionPath -Recurse ).Count | Should -Be 0
 
                 }
         }
@@ -89,7 +89,7 @@ Describe 'ScriptAnalyzer Rule Testing' {
          Context 'Private Functions' {
 
             It 'Passes the Script Analyzer ' {
-                (Invoke-ScriptAnalyzer -Path $PrivateFunctionPath ).Count | Should Be 0
+                (Invoke-ScriptAnalyzer -Path $PrivateFunctionPath ).Count | Should -Be 0
 
                 }
         }

--- a/Private/Tests/Get-CommonParameter.Tests.ps1
+++ b/Private/Tests/Get-CommonParameter.Tests.ps1
@@ -7,25 +7,25 @@
 
             It "Function $($function.Name) Has show-help comment block" {
 
-                $function.Definition.Contains('<#') | should be 'True'
-                $function.Definition.Contains('#>') | should be 'True'
+                $function.Definition.Contains('<#') | Should -Be 'True'
+                $function.Definition.Contains('#>') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Has show-help comment block has a.SYNOPSIS" {
 
-                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | should be 'True'
+                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | Should -Be 'True'
 
             }
 
             It "Function $($function.Name) Has show-help comment block has an example" {
 
-                $function.Definition.Contains('.EXAMPLE') | should be 'True'
+                $function.Definition.Contains('.EXAMPLE') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Is an advanced function" {
 
-                $function.CmdletBinding | should be 'True'
-                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | should be 'True'
+                $function.CmdletBinding | Should -Be 'True'
+                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
     
     }

--- a/Private/Tests/Get-CommonParameter.Tests.ps1
+++ b/Private/Tests/Get-CommonParameter.Tests.ps1
@@ -27,7 +27,7 @@
                 $function.CmdletBinding | Should -Be 'True'
                 $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
-    
+
     }
 
  }

--- a/Public/Export/Export-AllModuleFunction.ps1
+++ b/Public/Export/Export-AllModuleFunction.ps1
@@ -7,7 +7,7 @@
    Exposes all Private and Public Functions and exports them to a location that you tell it to Export to & Creates a Basic Shell Pester Test for the Function
 
 .PARAMETER Module
-    This should be passed the Module Name as a single string - for example 'PesterHelpers'
+    This Should -Be passed the Module Name as a single string - for example 'PesterHelpers'
 
 .PARAMETER OutPath
     This is the location that you want to output all the module files to. It is recommended not to use the same location as where the module is installed.

--- a/Public/Export/Export-AllModuleFunction.ps1
+++ b/Public/Export/Export-AllModuleFunction.ps1
@@ -23,7 +23,7 @@
     [Alias()]
     Param
     (
-        
+
         [Parameter(Mandatory=$true,
                    ValueFromPipelineByPropertyName=$true,
                    ValueFromPipeline=$true,
@@ -36,12 +36,12 @@
         $OutPath
     )
     $ModuleData = Get-Module $Module -Verbose:$VerbosePreference
-    
+
     If ($null -eq $ModuleData) {throw 'Please Import Module into session'}
     else {
-    Write-Verbose "$ModuleData" 
+    Write-Verbose "$ModuleData"
     $PublicFunctions = (Get-command -Module $module).Where{$_.CommandType -ne 'Cmdlet'}
-    
+
     Foreach ($PublicFunction in $PublicFunctions){
     Write-Verbose "Found $($PublicFunction.Name) being Exported"
     }
@@ -55,7 +55,7 @@
     }
 
     $PublicFunctions | ForEach-Object { Export-Function -Function $_.Name -ResolvedFunction $_ -OutPath $OutPath -Verbose:$VerbosePreference }
-    
+
     $PrivateFunctions | ForEach-Object { Export-Function -Function $_.Name -ResolvedFunction $_ -OutPath $OutPath -PrivateFunction -Verbose:$VerbosePreference }
     }
 }

--- a/Public/Export/Export-AllModuleFunction.ps1
+++ b/Public/Export/Export-AllModuleFunction.ps1
@@ -7,7 +7,7 @@
    Exposes all Private and Public Functions and exports them to a location that you tell it to Export to & Creates a Basic Shell Pester Test for the Function
 
 .PARAMETER Module
-    This Should -Be passed the Module Name as a single string - for example 'PesterHelpers'
+    This should be passed the Module Name as a single string - for example 'PesterHelpers'
 
 .PARAMETER OutPath
     This is the location that you want to output all the module files to. It is recommended not to use the same location as where the module is installed.

--- a/Public/Export/Export-Function.ps1
+++ b/Public/Export/Export-Function.ps1
@@ -10,7 +10,7 @@
     This Parameter takes a String input and is used in Both Parameter Sets
 
 .PARAMETER ResolvedFunction
-    This Should -Be passed the Function that you want to work with as an object making use of the following
+    This should be passed the Function that you want to work with as an object making use of the following
     $ResolvedFunction = Get-Command "Command"
 
 .PARAMETER OutPath

--- a/Public/Export/Export-Function.ps1
+++ b/Public/Export/Export-Function.ps1
@@ -10,7 +10,7 @@
     This Parameter takes a String input and is used in Both Parameter Sets
     
 .PARAMETER ResolvedFunction
-    This should be passed the Function that you want to work with as an object making use of the following
+    This Should -Be passed the Function that you want to work with as an object making use of the following
     $ResolvedFunction = Get-Command "Command"
     
 .PARAMETER OutPath

--- a/Public/Export/Export-Function.ps1
+++ b/Public/Export/Export-Function.ps1
@@ -2,33 +2,33 @@
  <#
 .Synopsis
     Exports a function from a module into a user given path
-    
+
 .Description
     As synopsis
 
 .PARAMETER Function
     This Parameter takes a String input and is used in Both Parameter Sets
-    
+
 .PARAMETER ResolvedFunction
     This Should -Be passed the Function that you want to work with as an object making use of the following
     $ResolvedFunction = Get-Command "Command"
-    
+
 .PARAMETER OutPath
     This is the location that you want to output all the module files to. It is recommended not to use the same location as where the module is installed.
     Also always check the files output what you expect them to.
-    
+
 .PARAMETER PrivateFunction
     This is a switch that is used to correctly export Private Functions and is used internally in Export-AllModuleFunction
-        
+
 .EXAMPLE
     Export-Function -Function Get-TwitterTweet -OutPath C:\TextFile\
-       
+
     This will export the function into the C:\TextFile\Get\Get-TwitterTweet.ps1 file and also create a basic test file C:\TextFile\Get\Get-TwitterTweet.Tests.ps1
 
 .EXAMPLE
-    Get-Command -Module SPCSPS | Where-Object {$_.CommandType -eq 'Function'}  | ForEach-Object { Export-Function -Function $_.Name -OutPath C:\TextFile\SPCSPS\ }    
-         
-    This will get all the Functions in the SPCSPS module (if it is loaded into memory or in a $env:PSModulePath as required by ModuleAutoLoading) and will export all the Functions into the C:\TextFile\SPCSPS\ folder under the respective Function Verbs. It will also create a basic Tests.ps1 file just like the prior example        
+    Get-Command -Module SPCSPS | Where-Object {$_.CommandType -eq 'Function'}  | ForEach-Object { Export-Function -Function $_.Name -OutPath C:\TextFile\SPCSPS\ }
+
+    This will get all the Functions in the SPCSPS module (if it is loaded into memory or in a $env:PSModulePath as required by ModuleAutoLoading) and will export all the Functions into the C:\TextFile\SPCSPS\ folder under the respective Function Verbs. It will also create a basic Tests.ps1 file just like the prior example
 #>
 [cmdletbinding(DefaultParameterSetName='Basic')]
 
@@ -59,10 +59,10 @@ Param(
     )
 
 $sb = New-Object -TypeName System.Text.StringBuilder
- 
+
  If (!($ResolvedFunction)) { $ResolvedFunction = Get-Command $function}
  $code = $ResolvedFunction | Select-Object -ExpandProperty Definition
-                
+
         If (!($PrivateFunction)) {
             $PublicOutPath = "$OutPath\Public\"
             $ps1 = "$PublicOutPath$($ResolvedFunction.Verb)\$($ResolvedFunction.Name).ps1"
@@ -72,7 +72,7 @@ $sb = New-Object -TypeName System.Text.StringBuilder
         }
 
         $sb.AppendLine("function $function {") | Out-Null
-        
+
         foreach ($line in $code -split '\r?\n') {
             $sb.AppendLine('{0}' -f $line) | Out-Null
         }
@@ -84,16 +84,14 @@ $sb = New-Object -TypeName System.Text.StringBuilder
 
         Set-Content -Path $ps1 -Value $($sb.ToString()) -Encoding UTF8
         Write-Verbose -Message "Added the content of function $Function into the file"
-        
+
         If(!($PrivateFunction)) {
         New-FunctionPesterTest -Function $Function -ResolvedFunction $ResolvedFunction -OutPath $PublicOutPath -Verbose:$VerbosePreference
-        Write-Verbose -Message "Created a Pester Test file for $Function Under the Basic ParamaterSet" 
+        Write-Verbose -Message "Created a Pester Test file for $Function Under the Basic ParamaterSet"
         }
         ElseIf ($PrivateFunction) {
         New-FunctionPesterTest -Function $Function -ResolvedFunction $ResolvedFunction -PrivateFunction -OutPath $OutPath -Verbose:$VerbosePreference
-        Write-Verbose -Message "Created a Pester Test file for $Function Under the Passthru ParamaterSet" 
+        Write-Verbose -Message "Created a Pester Test file for $Function Under the Passthru ParamaterSet"
         }
 
-
 }
-

--- a/Public/Export/Tests/Export-AllModuleFunction.Tests.ps1
+++ b/Public/Export/Tests/Export-AllModuleFunction.Tests.ps1
@@ -89,9 +89,7 @@
                 $function.CmdletBinding | Should -Be 'True'
                 $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
-    
+
     }
 
  }
-
-

--- a/Public/Export/Tests/Export-AllModuleFunction.Tests.ps1
+++ b/Public/Export/Tests/Export-AllModuleFunction.Tests.ps1
@@ -3,91 +3,91 @@
    Context 'Parameters for Export-AllModuleFunction'{
 
         It 'Has a Parameter called Module' {
-            $Function.Parameters.Keys.Contains('Module') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('Module') | Should -Be 'True'
             }
         It 'Module Parameter is Identified as Mandatory being True' {
-            [String]$Function.Parameters.Module.Attributes.Mandatory | Should be 'True'
+            [String]$Function.Parameters.Module.Attributes.Mandatory | Should -Be 'True'
             }
         It 'Module Parameter is of String Type' {
-            $Function.Parameters.Module.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.Module.ParameterType.FullName | Should -Be 'System.String'
             }
         It 'Module Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.Module.ParameterSets.Keys | Should Be '__AllParameterSets'
+            [String]$Function.Parameters.Module.ParameterSets.Keys | Should -Be '__AllParameterSets'
             }
         It 'Module Parameter Position is defined correctly' {
-            [String]$Function.Parameters.Module.Attributes.Position | Should be '0'
+            [String]$Function.Parameters.Module.Attributes.Position | Should -Be '0'
             }
         It 'Does Module Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.Module.Attributes.ValueFromPipeline | Should be 'True'
+            [String]$Function.Parameters.Module.Attributes.ValueFromPipeline | Should -Be 'True'
             }
         It 'Does Module Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.Module.Attributes.ValueFromPipelineByPropertyName | Should be 'True'
+            [String]$Function.Parameters.Module.Attributes.ValueFromPipelineByPropertyName | Should -Be 'True'
             }
         It 'Does Module Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.Module.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for Module '{
-            $function.Definition.Contains('.PARAMETER Module') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER Module') | Should -Be 'True'
             }
         It 'Has a Parameter called OutPath' {
-            $Function.Parameters.Keys.Contains('OutPath') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('OutPath') | Should -Be 'True'
             }
         It 'OutPath Parameter is Identified as Mandatory being True' {
-            [String]$Function.Parameters.OutPath.Attributes.Mandatory | Should be 'True'
+            [String]$Function.Parameters.OutPath.Attributes.Mandatory | Should -Be 'True'
             }
         It 'OutPath Parameter is of String Type' {
-            $Function.Parameters.OutPath.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.OutPath.ParameterType.FullName | Should -Be 'System.String'
             }
         It 'OutPath Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.OutPath.ParameterSets.Keys | Should Be '__AllParameterSets'
+            [String]$Function.Parameters.OutPath.ParameterSets.Keys | Should -Be '__AllParameterSets'
             }
         It 'OutPath Parameter Position is defined correctly' {
-            [String]$Function.Parameters.OutPath.Attributes.Position | Should be '-2147483648'
+            [String]$Function.Parameters.OutPath.Attributes.Position | Should -Be '-2147483648'
             }
         It 'Does OutPath Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipeline | Should be 'False'
+            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipeline | Should -Be 'False'
             }
         It 'Does OutPath Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipelineByPropertyName | Should be 'False'
+            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False'
             }
         It 'Does OutPath Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for OutPath '{
-            $function.Definition.Contains('.PARAMETER OutPath') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER OutPath') | Should -Be 'True'
             }
     }
     Context "Function $($function.Name) - Help Section" {
 
             It "Function $($function.Name) Has show-help comment block" {
 
-                $function.Definition.Contains('<#') | should be 'True'
-                $function.Definition.Contains('#>') | should be 'True'
+                $function.Definition.Contains('<#') | Should -Be 'True'
+                $function.Definition.Contains('#>') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Has show-help comment block has a.SYNOPSIS" {
 
-                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | should be 'True'
+                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | Should -Be 'True'
 
             }
 
             It "Function $($function.Name) Has show-help comment block has an example" {
 
-                $function.Definition.Contains('.EXAMPLE') | should be 'True'
+                $function.Definition.Contains('.EXAMPLE') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Is an advanced function" {
 
-                $function.CmdletBinding | should be 'True'
-                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | should be 'True'
+                $function.CmdletBinding | Should -Be 'True'
+                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
     
     }

--- a/Public/Export/Tests/Export-Function.Functional.Tests.ps1
+++ b/Public/Export/Tests/Export-Function.Functional.Tests.ps1
@@ -28,47 +28,47 @@
        
               
        It "Passes the Functional Mock" {   
-           Export-Function -Function New-FunctionPesterTest -OutPath C:\TextFile\PTest\ -Verbose:$VerbosePreference | Should be "New-FunctionPesterTest"
+           Export-Function -Function New-FunctionPesterTest -OutPath C:\TextFile\PTest\ -Verbose:$VerbosePreference | Should -Be "New-FunctionPesterTest"
            Assert-MockCalled -CommandName Export-Function -Times 1
            
        }
 
        It "Calls New-FunctionPesterTest" {
-            New-FunctionPesterTest -Function $FunctionValue -OutPath $OutpathValue -Verbose:$VerbosePreference | Should Be "New-FunctionPesterTest"
+            New-FunctionPesterTest -Function $FunctionValue -OutPath $OutpathValue -Verbose:$VerbosePreference | Should -Be "New-FunctionPesterTest"
             Assert-MockCalled -CommandName New-FunctionPesterTest -Times 1
             }
 
 
 
        It "Creates the required Objects" {
-           New-Object -TypeName System.Text.StringBuilder | Should Be "SB"
+           New-Object -TypeName System.Text.StringBuilder | Should -Be "SB"
            Assert-MockCalled -CommandName New-Object -Times 1
            }
 
        It "Creates the New-FunctionPesterTest File" {
 
-       New-Item -Path $tests -ItemType "File" -Force | Should Be "New-FunctionPesterTest.ps1"
+       New-Item -Path $tests -ItemType "File" -Force | Should -Be "New-FunctionPesterTest.ps1"
        Assert-MockCalled -CommandName New-Item -Times 1
        
        }
        
        It "Sets Content of the New-FunctionPesterTest File" {
 
-       Set-Content -Path $tests -Value $ExpectedValue | Should be "New-FunctionPesterTest.ps1"
+       Set-Content -Path $tests -Value $ExpectedValue | Should -Be "New-FunctionPesterTest.ps1"
        Assert-MockCalled -CommandName Set-Content -Times 1 -Scope It
        
        }
 
        It "Mocked Out-Null" {
 
-       Out-Null | Should BeNullOrEmpty 
+       Out-Null | Should -BeNullOrEmpty 
        Assert-MockCalled -CommandName Out-Null -Times 1
        }
        
 
        It "Mocked Write-Verbose" {
 
-       Write-Verbose "$VerboseMessage1" } | Should BeNullOrEmpty
+       Write-Verbose "$VerboseMessage1" } | Should -BeNullOrEmpty
        Assert-MockCalled -CommandName Write-Verbose -Times 1
 
 

--- a/Public/Export/Tests/Export-Function.Functional.Tests.ps1
+++ b/Public/Export/Tests/Export-Function.Functional.Tests.ps1
@@ -2,35 +2,35 @@
 
         $FunctionValue = "New-FunctionPesterTest"
         $FunctionVerbValue = "New"
-        
+
         $OutpathValue = 'C:\TextFile\PTest\'
         $NewItemPath = "$OutpathValue\$FunctionVerbValue\$FunctionValue.ps1"
         $tests = $NewItemPath
 
         $VerboseMessage1 = "Full Output path is $tests"
-        
+
 
 
 
         Mock Export-Function {'New-FunctionPesterTest'} -Verifiable -ParameterFilter { $Function -eq $FunctionValue -and $OutPath -eq $OutpathValue }
-        
+
         Mock New-Object {"SB"} -ParameterFilter {$TypeName -eq "System.Text.StringBuilder"} -Verifiable
-        
-        Mock Out-Null {} -Verifiable 
-        
-        Mock New-FunctionPesterTest {"New-FunctionPesterTest"} -Verifiable -ParameterFilter  { $Function -eq $FunctionValue -and $OutPath -eq $OutpathValue -and $VerbosePreference -eq $VerbosePreference } 
-                   
-        Mock New-Item {"New-FunctionPesterTest.ps1" } -Verifiable -ParameterFilter {$path -eq $tests -and $ItemType -eq "File" -and $force -eq $true } 
-        
+
+        Mock Out-Null {} -Verifiable
+
+        Mock New-FunctionPesterTest {"New-FunctionPesterTest"} -Verifiable -ParameterFilter  { $Function -eq $FunctionValue -and $OutPath -eq $OutpathValue -and $VerbosePreference -eq $VerbosePreference }
+
+        Mock New-Item {"New-FunctionPesterTest.ps1" } -Verifiable -ParameterFilter {$path -eq $tests -and $ItemType -eq "File" -and $force -eq $true }
+
         Mock Set-Content {"New-FunctionPesterTest.ps1"} -Verifiable -ParameterFilter { $Path -eq $tests -and $Value -eq $ExpectedValue }
-         
-        Mock Write-Verbose {$VerboseMessage1} -Verifiable -ParameterFilter { $message -eq $VerboseMessage1}   
-       
-              
-       It "Passes the Functional Mock" {   
+
+        Mock Write-Verbose {$VerboseMessage1} -Verifiable -ParameterFilter { $message -eq $VerboseMessage1}
+
+
+       It "Passes the Functional Mock" {
            Export-Function -Function New-FunctionPesterTest -OutPath C:\TextFile\PTest\ -Verbose:$VerbosePreference | Should -Be "New-FunctionPesterTest"
            Assert-MockCalled -CommandName Export-Function -Times 1
-           
+
        }
 
        It "Calls New-FunctionPesterTest" {
@@ -49,22 +49,22 @@
 
        New-Item -Path $tests -ItemType "File" -Force | Should -Be "New-FunctionPesterTest.ps1"
        Assert-MockCalled -CommandName New-Item -Times 1
-       
+
        }
-       
+
        It "Sets Content of the New-FunctionPesterTest File" {
 
        Set-Content -Path $tests -Value $ExpectedValue | Should -Be "New-FunctionPesterTest.ps1"
        Assert-MockCalled -CommandName Set-Content -Times 1 -Scope It
-       
+
        }
 
        It "Mocked Out-Null" {
 
-       Out-Null | Should -BeNullOrEmpty 
+       Out-Null | Should -BeNullOrEmpty
        Assert-MockCalled -CommandName Out-Null -Times 1
        }
-       
+
 
        It "Mocked Write-Verbose" {
 
@@ -75,7 +75,7 @@
 
        It "Mocked everything correctly" { Assert-VerifiableMock }
 
-       
+
  }
 
 

--- a/Public/Export/Tests/Export-Function.Tests.ps1
+++ b/Public/Export/Tests/Export-Function.Tests.ps1
@@ -3,153 +3,153 @@
    Context 'Parameters for Export-Function'{
 
         It 'Has a Parameter called Function' {
-            $Function.Parameters.Keys.Contains('Function') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('Function') | Should -Be 'True'
             }
         It 'Function Parameter is Identified as Mandatory being True True' {
-            [String]$Function.Parameters.Function.Attributes.Mandatory | Should be 'True True'
+            [String]$Function.Parameters.Function.Attributes.Mandatory | Should -Be 'True True'
             }
         It 'Function Parameter is of String Type' {
-            $Function.Parameters.Function.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.Function.ParameterType.FullName | Should -Be 'System.String'
             }
         It 'Function Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.Function.ParameterSets.Keys | Should Be 'Passthru Basic'
+            [String]$Function.Parameters.Function.ParameterSets.Keys | Should -Be 'Passthru Basic'
             }
         It 'Function Parameter Position is defined correctly' {
-            [String]$Function.Parameters.Function.Attributes.Position | Should be '-2147483648 -2147483648'
+            [String]$Function.Parameters.Function.Attributes.Position | Should -Be '-2147483648 -2147483648'
             }
         It 'Does Function Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.Function.Attributes.ValueFromPipeline | Should be 'True True'
+            [String]$Function.Parameters.Function.Attributes.ValueFromPipeline | Should -Be 'True True'
             }
         It 'Does Function Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.Function.Attributes.ValueFromPipelineByPropertyName | Should be 'True True'
+            [String]$Function.Parameters.Function.Attributes.ValueFromPipelineByPropertyName | Should -Be 'True True'
             }
         It 'Does Function Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'True'
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'True'
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'True'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'True'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for Function '{
-            $function.Definition.Contains('.PARAMETER Function') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER Function') | Should -Be 'True'
             }
         It 'Has a Parameter called ResolvedFunction' {
-            $Function.Parameters.Keys.Contains('ResolvedFunction') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('ResolvedFunction') | Should -Be 'True'
             }
         It 'ResolvedFunction Parameter is Identified as Mandatory being True' {
-            [String]$Function.Parameters.ResolvedFunction.Attributes.Mandatory | Should be 'True'
+            [String]$Function.Parameters.ResolvedFunction.Attributes.Mandatory | Should -Be 'True'
             }
         It 'ResolvedFunction Parameter is of Object Type' {
-            $Function.Parameters.ResolvedFunction.ParameterType.FullName | Should be 'System.Object'
+            $Function.Parameters.ResolvedFunction.ParameterType.FullName | Should -Be 'System.Object'
             }
         It 'ResolvedFunction Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.ResolvedFunction.ParameterSets.Keys | Should Be 'Passthru'
+            [String]$Function.Parameters.ResolvedFunction.ParameterSets.Keys | Should -Be 'Passthru'
             }
         It 'ResolvedFunction Parameter Position is defined correctly' {
-            [String]$Function.Parameters.ResolvedFunction.Attributes.Position | Should be '-2147483648'
+            [String]$Function.Parameters.ResolvedFunction.Attributes.Position | Should -Be '-2147483648'
             }
         It 'Does ResolvedFunction Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.ResolvedFunction.Attributes.ValueFromPipeline | Should be 'False'
+            [String]$Function.Parameters.ResolvedFunction.Attributes.ValueFromPipeline | Should -Be 'False'
             }
         It 'Does ResolvedFunction Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.ResolvedFunction.Attributes.ValueFromPipelineByPropertyName | Should be 'False'
+            [String]$Function.Parameters.ResolvedFunction.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False'
             }
         It 'Does ResolvedFunction Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for ResolvedFunction '{
-            $function.Definition.Contains('.PARAMETER ResolvedFunction') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER ResolvedFunction') | Should -Be 'True'
             }
         It 'Has a Parameter called OutPath' {
-            $Function.Parameters.Keys.Contains('OutPath') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('OutPath') | Should -Be 'True'
             }
         It 'OutPath Parameter is Identified as Mandatory being True True' {
-            [String]$Function.Parameters.OutPath.Attributes.Mandatory | Should be 'True True'
+            [String]$Function.Parameters.OutPath.Attributes.Mandatory | Should -Be 'True True'
             }
         It 'OutPath Parameter is of String Type' {
-            $Function.Parameters.OutPath.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.OutPath.ParameterType.FullName | Should -Be 'System.String'
             }
         It 'OutPath Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.OutPath.ParameterSets.Keys | Should Be 'Passthru Basic'
+            [String]$Function.Parameters.OutPath.ParameterSets.Keys | Should -Be 'Passthru Basic'
             }
         It 'OutPath Parameter Position is defined correctly' {
-            [String]$Function.Parameters.OutPath.Attributes.Position | Should be '-2147483648 -2147483648'
+            [String]$Function.Parameters.OutPath.Attributes.Position | Should -Be '-2147483648 -2147483648'
             }
         It 'Does OutPath Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipeline | Should be 'False False'
+            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipeline | Should -Be 'False False'
             }
         It 'Does OutPath Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipelineByPropertyName | Should be 'False False'
+            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False False'
             }
         It 'Does OutPath Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for OutPath '{
-            $function.Definition.Contains('.PARAMETER OutPath') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER OutPath') | Should -Be 'True'
             }
         It 'Has a Parameter called PrivateFunction' {
-            $Function.Parameters.Keys.Contains('PrivateFunction') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('PrivateFunction') | Should -Be 'True'
             }
         It 'PrivateFunction Parameter is Identified as Mandatory being False' {
-            [String]$Function.Parameters.PrivateFunction.Attributes.Mandatory | Should be 'False'
+            [String]$Function.Parameters.PrivateFunction.Attributes.Mandatory | Should -Be 'False'
             }
         It 'PrivateFunction Parameter is of SwitchParameter Type' {
-            $Function.Parameters.PrivateFunction.ParameterType.FullName | Should be 'System.Management.Automation.SwitchParameter'
+            $Function.Parameters.PrivateFunction.ParameterType.FullName | Should -Be 'System.Management.Automation.SwitchParameter'
             }
         It 'PrivateFunction Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.PrivateFunction.ParameterSets.Keys | Should Be 'Passthru'
+            [String]$Function.Parameters.PrivateFunction.ParameterSets.Keys | Should -Be 'Passthru'
             }
         It 'PrivateFunction Parameter Position is defined correctly' {
-            [String]$Function.Parameters.PrivateFunction.Attributes.Position | Should be '-2147483648'
+            [String]$Function.Parameters.PrivateFunction.Attributes.Position | Should -Be '-2147483648'
             }
         It 'Does PrivateFunction Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.PrivateFunction.Attributes.ValueFromPipeline | Should be 'False'
+            [String]$Function.Parameters.PrivateFunction.Attributes.ValueFromPipeline | Should -Be 'False'
             }
         It 'Does PrivateFunction Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.PrivateFunction.Attributes.ValueFromPipelineByPropertyName | Should be 'False'
+            [String]$Function.Parameters.PrivateFunction.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False'
             }
         It 'Does PrivateFunction Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for PrivateFunction '{
-            $function.Definition.Contains('.PARAMETER PrivateFunction') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER PrivateFunction') | Should -Be 'True'
             }
     }
     Context "Function $($function.Name) - Help Section" {
 
             It "Function $($function.Name) Has show-help comment block" {
 
-                $function.Definition.Contains('<#') | should be 'True'
-                $function.Definition.Contains('#>') | should be 'True'
+                $function.Definition.Contains('<#') | Should -Be 'True'
+                $function.Definition.Contains('#>') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Has show-help comment block has a.SYNOPSIS" {
 
-                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | should be 'True'
+                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | Should -Be 'True'
 
             }
 
             It "Function $($function.Name) Has show-help comment block has an example" {
 
-                $function.Definition.Contains('.EXAMPLE') | should be 'True'
+                $function.Definition.Contains('.EXAMPLE') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Is an advanced function" {
 
-                $function.CmdletBinding | should be 'True'
-                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | should be 'True'
+                $function.CmdletBinding | Should -Be 'True'
+                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
     
     }

--- a/Public/Export/Tests/Export-Function.Tests.ps1
+++ b/Public/Export/Tests/Export-Function.Tests.ps1
@@ -151,7 +151,7 @@
                 $function.CmdletBinding | Should -Be 'True'
                 $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
-    
+
     }
 
  }

--- a/Public/New/New-FunctionFile.ps1
+++ b/Public/New/New-FunctionFile.ps1
@@ -12,13 +12,13 @@
 #>
 
 [Cmdletbinding(SupportsShouldProcess=$true)]
-param($FunctionName) 
+param($FunctionName)
 
 
 if ($PSCmdlet.ShouldProcess($OutPath,"Creating function & pester test Files for $Function"))
 {
-$verb = $functionName.split('-')[0] 
-New-Item .\$verb\$functionName.ps1 -Force | Out-Null 
+$verb = $functionName.split('-')[0]
+New-Item .\$verb\$functionName.ps1 -Force | Out-Null
 
 $value = @'
 Function $functionName {
@@ -73,8 +73,7 @@ Function $functionName {
 $value = $value.Replace('$functionName',$functionName)
 Set-Content -Path .\$verb\$functionName.ps1 -Value $value -Encoding UTF8
 
-New-Item .\$verb\$functionName.Tests.ps1 -Force | Out-Null 
+New-Item .\$verb\$functionName.Tests.ps1 -Force | Out-Null
 }
 
 }
-

--- a/Public/New/New-FunctionPesterTest.ps1
+++ b/Public/New/New-FunctionPesterTest.ps1
@@ -15,7 +15,7 @@ Function New-FunctionPesterTest {
     This Parameter takes a String input and is used in Both Parameter Sets
     
 .PARAMETER ResolvedFunction
-    This should be passed the Function that you want to work with as an object making use of the following
+    This Should -Be passed the Function that you want to work with as an object making use of the following
     $ResolvedFunction = Get-Command "Command"
 
 .PARAMETER OutPath
@@ -122,35 +122,35 @@ If ($FunctionParams.Count -gt 0)  {
 foreach ($Parameter in $Parameters) {
     $ParamText = @'
         It 'Has a Parameter called $Parameter' {
-            $Function.Parameters.Keys.Contains('$Parameter') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('$Parameter') | Should -Be 'True'
             }
         It '$Parameter Parameter is Identified as Mandatory being $MandatoryValue' {
-            [String]$Function.Parameters.$Parameter.Attributes.Mandatory | Should be $Mandatory
+            [String]$Function.Parameters.$Parameter.Attributes.Mandatory | Should -Be $Mandatory
             }
         It '$Parameter Parameter is of String Type' {
-            $Function.Parameters.$Parameter.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.$Parameter.ParameterType.FullName | Should -Be 'System.String'
             }
         It '$Parameter Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.$Parameter.ParameterSets.Keys | Should Be $ParamSets
+            [String]$Function.Parameters.$Parameter.ParameterSets.Keys | Should -Be $ParamSets
             }
         It '$Parameter Parameter Position is defined correctly' {
-            [String]$Function.Parameters.$Parameter.Attributes.Position | Should be $Positions
+            [String]$Function.Parameters.$Parameter.Attributes.Position | Should -Be $Positions
             }
         It 'Does $Parameter Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.$Parameter.Attributes.ValueFromPipeline | Should be $ValueFromPipeline
+            [String]$Function.Parameters.$Parameter.Attributes.ValueFromPipeline | Should -Be $ValueFromPipeline
             }
         It 'Does $Parameter Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.$Parameter.Attributes.ValueFromPipelineByPropertyName | Should be $PipelineByPropertyName
+            [String]$Function.Parameters.$Parameter.Attributes.ValueFromPipelineByPropertyName | Should -Be $PipelineByPropertyName
             }
         It 'Does $Parameter Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be $VNNEAttribute
-            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be $VNNAttribute
-            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be $VSAttribute
-            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be $VRAttribute
-            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be $VRPattern
+            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be $VNNEAttribute
+            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be $VNNAttribute
+            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be $VSAttribute
+            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be $VRAttribute
+            $Function.Parameters.$Parameter.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be $VRPattern
             }
         It 'Has Parameter Help Text for $Parameter '{
-            $function.Definition.Contains('.PARAMETER $Parameter') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER $Parameter') | Should -Be 'True'
             }
 '@
 
@@ -200,25 +200,25 @@ $HelpTests = @'
 
             It "Function $($function.Name) Has show-help comment block" {
 
-                $function.Definition.Contains('<#') | should be 'True'
-                $function.Definition.Contains('#>') | should be 'True'
+                $function.Definition.Contains('<#') | Should -Be 'True'
+                $function.Definition.Contains('#>') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Has show-help comment block has a.SYNOPSIS" {
 
-                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | should be 'True'
+                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | Should -Be 'True'
 
             }
 
             It "Function $($function.Name) Has show-help comment block has an example" {
 
-                $function.Definition.Contains('.EXAMPLE') | should be 'True'
+                $function.Definition.Contains('.EXAMPLE') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Is an advanced function" {
 
-                $function.CmdletBinding | should be 'True'
-                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | should be 'True'
+                $function.CmdletBinding | Should -Be 'True'
+                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
     
     }

--- a/Public/New/New-FunctionPesterTest.ps1
+++ b/Public/New/New-FunctionPesterTest.ps1
@@ -13,7 +13,7 @@ Function New-FunctionPesterTest {
 
 .PARAMETER Function
     This Parameter takes a String input and is used in Both Parameter Sets
-    
+
 .PARAMETER ResolvedFunction
     This Should -Be passed the Function that you want to work with as an object making use of the following
     $ResolvedFunction = Get-Command "Command"
@@ -85,7 +85,7 @@ if ($PSCmdlet.ShouldProcess($OutPath,"Creating Pester test File for $Function"))
                                 $FunctionalTests = "$OutPath\$($ResolvedFunction.Verb)\Tests\$($ResolvedFunction.Name).Functional.Tests.ps1" }
     Elseif ($PrivateFunction) { $Tests = "$OutPath\Private\Tests\$Function.Tests.ps1"
                                 $FunctionalTests = "$OutPath\Private\Tests\$Function.Functional.Tests.ps1" }
-    
+
     $FunctionParams   = $ResolvedFunction.Parameters.Keys
 
 $VerboseMessage = "Full Output path is $Tests"
@@ -154,7 +154,7 @@ foreach ($Parameter in $Parameters) {
             }
 '@
 
-    
+
     $Mandatory = $($ResolvedFunction.Parameters[$parameter].Attributes.Mandatory)
     $Type      = $($ResolvedFunction.Parameters[$parameter].ParameterType.Name)
     $FullType  = $($ResolvedFunction.Parameters[$parameter].ParameterType.FullName)
@@ -175,7 +175,7 @@ foreach ($Parameter in $Parameters) {
     $ParamText = $ParamText.Replace('$VNNAttribute',"'$VNNAttribute'")
     $ParamText = $ParamText.Replace('$VSAttribute',"'$VSAttribute'")
     $ParamText = $ParamText.Replace('$VRAttribute',"'$VRAttribute'")
-    $ParamText = $ParamText.Replace('$VRPattern',"'$VRPattern'")  
+    $ParamText = $ParamText.Replace('$VRPattern',"'$VRPattern'")
     $ParamText = $ParamText.Replace('$Mandatory',"'$Mandatory'")
     $ParamText = $ParamText.Replace('$ParamSets',"'$ParamSets'")
     $ParamText = $ParamText.Replace('$Positions',"'$Positions'")
@@ -184,7 +184,7 @@ foreach ($Parameter in $Parameters) {
     $ParamText = $ParamText.Replace("String Type","$Type Type")
     $ParamText = $ParamText.Replace("System.String",$FullType)
 
-    
+
     $SB.AppendLine($ParamText) | Out-Null
 
     Write-Verbose -Message "Added the Parameter Pester Tests for the $Parameter Parameter"
@@ -220,7 +220,7 @@ $HelpTests = @'
                 $function.CmdletBinding | Should -Be 'True'
                 $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
-    
+
     }
 '@
 

--- a/Public/New/New-FunctionPesterTest.ps1
+++ b/Public/New/New-FunctionPesterTest.ps1
@@ -15,7 +15,7 @@ Function New-FunctionPesterTest {
     This Parameter takes a String input and is used in Both Parameter Sets
 
 .PARAMETER ResolvedFunction
-    This Should -Be passed the Function that you want to work with as an object making use of the following
+    This should be passed the Function that you want to work with as an object making use of the following
     $ResolvedFunction = Get-Command "Command"
 
 .PARAMETER OutPath

--- a/Public/New/New-ModulePesterTest.ps1
+++ b/Public/New/New-ModulePesterTest.ps1
@@ -13,7 +13,7 @@ As synopsis
 .EXAMPLE
 New-ModulePesterTests -ModuleName SPCSPS
 
-This will get the SPCSPS module and the path that is asocciated with it and then create a ps1 file that contains a base level of Pester Tests         
+This will get the SPCSPS module and the path that is asocciated with it and then create a ps1 file that contains a base level of Pester Tests
 #>
 [CmdletBinding(SupportsShouldProcess=$true)]
 Param (
@@ -28,10 +28,10 @@ Param (
 
     New-Item -Path "$OutPath\$ModuleName.Full.Tests.ps1" -ItemType File -Force | Out-Null
     Set-Content -Path "$OutPath\$ModuleName.Full.Tests.ps1" -Value $FullModulePesterTests -Encoding UTF8 | Out-Null
-    
+
     New-Item -Path "$OutPath\$ModuleName.Norm.Tests.ps1" -ItemType File -Force | Out-Null
     Set-Content -Path "$OutPath\$ModuleName.Norm.Tests.ps1" -Value $NormModulePesterTests -Encoding UTF8 | Out-Null
-    
+
     New-Item -Path "$OutPath\$ModuleName.Min.Tests.ps1" -ItemType File -Force | Out-Null
     Set-Content -Path "$OutPath\$ModuleName.Min.Tests.ps1" -Value $MinModulePesterTests -Encoding UTF8 | Out-Null
     }

--- a/Public/New/Tests/New-FunctionFile.Tests.ps1
+++ b/Public/New/Tests/New-FunctionFile.Tests.ps1
@@ -3,60 +3,60 @@
    Context 'Parameters for New-FunctionFile'{
 
         It 'Has a Parameter called FunctionName' {
-            $Function.Parameters.Keys.Contains('FunctionName') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('FunctionName') | Should -Be 'True'
             }
         It 'FunctionName Parameter is Identified as Mandatory being False' {
-            [String]$Function.Parameters.FunctionName.Attributes.Mandatory | Should be 'False'
+            [String]$Function.Parameters.FunctionName.Attributes.Mandatory | Should -Be 'False'
             }
         It 'FunctionName Parameter is of Object Type' {
-            $Function.Parameters.FunctionName.ParameterType.FullName | Should be 'System.Object'
+            $Function.Parameters.FunctionName.ParameterType.FullName | Should -Be 'System.Object'
             }
         It 'FunctionName Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.FunctionName.ParameterSets.Keys | Should Be '__AllParameterSets'
+            [String]$Function.Parameters.FunctionName.ParameterSets.Keys | Should -Be '__AllParameterSets'
             }
         It 'FunctionName Parameter Position is defined correctly' {
-            [String]$Function.Parameters.FunctionName.Attributes.Position | Should be '0'
+            [String]$Function.Parameters.FunctionName.Attributes.Position | Should -Be '0'
             }
         It 'Does FunctionName Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.FunctionName.Attributes.ValueFromPipeline | Should be 'False'
+            [String]$Function.Parameters.FunctionName.Attributes.ValueFromPipeline | Should -Be 'False'
             }
         It 'Does FunctionName Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.FunctionName.Attributes.ValueFromPipelineByPropertyName | Should be 'False'
+            [String]$Function.Parameters.FunctionName.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False'
             }
         It 'Does FunctionName Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.FunctionName.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for FunctionName '{
-            $function.Definition.Contains('.PARAMETER FunctionName') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER FunctionName') | Should -Be 'True'
             }
     }
     Context "Function $($function.Name) - Help Section" {
 
             It "Function $($function.Name) Has show-help comment block" {
 
-                $function.Definition.Contains('<#') | should be 'True'
-                $function.Definition.Contains('#>') | should be 'True'
+                $function.Definition.Contains('<#') | Should -Be 'True'
+                $function.Definition.Contains('#>') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Has show-help comment block has a.SYNOPSIS" {
 
-                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | should be 'True'
+                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | Should -Be 'True'
 
             }
 
             It "Function $($function.Name) Has show-help comment block has an example" {
 
-                $function.Definition.Contains('.EXAMPLE') | should be 'True'
+                $function.Definition.Contains('.EXAMPLE') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Is an advanced function" {
 
-                $function.CmdletBinding | should be 'True'
-                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | should be 'True'
+                $function.CmdletBinding | Should -Be 'True'
+                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
     
     }

--- a/Public/New/Tests/New-FunctionFile.Tests.ps1
+++ b/Public/New/Tests/New-FunctionFile.Tests.ps1
@@ -58,7 +58,7 @@
                 $function.CmdletBinding | Should -Be 'True'
                 $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
-    
+
     }
 
  }

--- a/Public/New/Tests/New-FunctionPesterTest.Functional.Tests.ps1
+++ b/Public/New/Tests/New-FunctionPesterTest.Functional.Tests.ps1
@@ -12,23 +12,23 @@ $function = Get-Command -Name Export-Function
 Describe 'Export-Function Tests' {
    Context 'Parameters for Export-Function'{
 It 'Has a parameter called Function' {
-            $function.Parameters.Keys.Contains('Function') | Should Be 'True'
+            $function.Parameters.Keys.Contains('Function') | Should -Be 'True'
             }
         It 'Function Parameter is Correctly Identified as being Mandatory' {
-            $function.Parameters.Function.Attributes.Mandatory | Should be 'True'
+            $function.Parameters.Function.Attributes.Mandatory | Should -Be 'True'
             }
         It 'Function Parameter is of String Type' {
-            $function.Parameters.Function.ParameterType.FullName | Should be 'System.String'
+            $function.Parameters.Function.ParameterType.FullName | Should -Be 'System.String'
             }
 
 It 'Has a parameter called OutPath' {
-            $function.Parameters.Keys.Contains('OutPath') | Should Be 'True'
+            $function.Parameters.Keys.Contains('OutPath') | Should -Be 'True'
             }
         It 'OutPath Parameter is Correctly Identified as being Mandatory' {
-            $function.Parameters.OutPath.Attributes.Mandatory | Should be 'True'
+            $function.Parameters.OutPath.Attributes.Mandatory | Should -Be 'True'
             }
         It 'OutPath Parameter is of String Type' {
-            $function.Parameters.OutPath.ParameterType.FullName | Should be 'System.String'
+            $function.Parameters.OutPath.ParameterType.FullName | Should -Be 'System.String'
             }
 
       }
@@ -53,41 +53,41 @@ It 'Has a parameter called OutPath' {
        
        
        It "Passes the Functional Mock" {   
-           New-FunctionPesterTest -Function Export-Function -OutPath C:\TextFile\PTest\ | Should be "Export-Function"
+           New-FunctionPesterTest -Function Export-Function -OutPath C:\TextFile\PTest\ | Should -Be "Export-Function"
            Assert-MockCalled -CommandName New-FunctionPesterTest -Times 1
            
        }
        
        It "Creates the required Objects" {
-       New-Object -TypeName System.Text.StringBuilder | Should Be "SB"
-       New-Object -TypeName System.Collections.ArrayList | Should Be "ArrayList"
+       New-Object -TypeName System.Text.StringBuilder | Should -Be "SB"
+       New-Object -TypeName System.Collections.ArrayList | Should -Be "ArrayList"
        Assert-MockCalled -CommandName New-Object -Times 2
        }
        
        It "Creates the Export-Function Pester Test File" {
 
-       New-Item -Path $tests -ItemType "File" -Force | Should Be "Export-Function.Test.ps1"
+       New-Item -Path $tests -ItemType "File" -Force | Should -Be "Export-Function.Test.ps1"
        Assert-MockCalled -CommandName New-Item -Times 1
        
        }
        
        It "Sets Content of the Export-Function Pester Test File" {
 
-       Set-Content -Path $tests -Value $ExpectedValue | Should be "Export-Function.Test.ps1"
+       Set-Content -Path $tests -Value $ExpectedValue | Should -Be "Export-Function.Test.ps1"
        Assert-MockCalled -CommandName Set-Content -Times 1 -Scope It
        
        }
 
        It "Mocked Out-Null" {
 
-       Out-Null | Should BeNullOrEmpty 
+       Out-Null | Should -BeNullOrEmpty 
        Assert-MockCalled -CommandName Out-Null -Times 1
        }
        
 
        It "Mocked Write-Verbose" {
 
-       Write-Verbose "$VerboseMessage1" } | Should BeNullOrEmpty
+       Write-Verbose "$VerboseMessage1" } | Should -BeNullOrEmpty
        Assert-MockCalled -CommandName Write-Verbose -Times 1
 
 

--- a/Public/New/Tests/New-FunctionPesterTest.Functional.Tests.ps1
+++ b/Public/New/Tests/New-FunctionPesterTest.Functional.Tests.ps1
@@ -2,7 +2,7 @@
 
         $FunctionValue = "Export-Function"
         $FunctionVerbValue = "Export"
-        
+
         $OutpathValue = 'C:\TextFile\PTest\'
         $NewItemPath = "$OutpathValue\$FunctionVerbValue\$FunctionValue.Tests.ps1"
         $tests = $NewItemPath
@@ -36,54 +36,54 @@ It 'Has a parameter called OutPath' {
  }
 '@
         $VerboseMessage1 = "Full Output path is $tests"
-        
+
         Mock New-Object {"SB"} -ParameterFilter {$TypeName -eq "System.Text.StringBuilder"} -Verifiable
-        
+
         Mock New-Object {"ArrayList"} -ParameterFilter {$TypeName -eq "System.Collections.Arraylist"} -Verifiable
 
-        Mock Out-Null {} -Verifiable 
-        
-        Mock New-FunctionPesterTest {"Export-Function"} -Verifiable -ParameterFilter  { $Function -eq $FunctionValue -and $OutPath -eq $OutpathValue } 
-                   
-        Mock New-Item {"Export-Function.Test.ps1" } -Verifiable -ParameterFilter {$path -eq $tests -and $ItemType -eq "File" -and $force -eq $true } 
-        
+        Mock Out-Null {} -Verifiable
+
+        Mock New-FunctionPesterTest {"Export-Function"} -Verifiable -ParameterFilter  { $Function -eq $FunctionValue -and $OutPath -eq $OutpathValue }
+
+        Mock New-Item {"Export-Function.Test.ps1" } -Verifiable -ParameterFilter {$path -eq $tests -and $ItemType -eq "File" -and $force -eq $true }
+
         Mock Set-Content {"Export-Function.Test.ps1"} -Verifiable -ParameterFilter { $Path -eq $tests -and $Value -eq $ExpectedValue }
-         
-        Mock Write-Verbose {$VerboseMessage1} -Verifiable -ParameterFilter { $message -eq $VerboseMessage1}   
-       
-       
-       It "Passes the Functional Mock" {   
+
+        Mock Write-Verbose {$VerboseMessage1} -Verifiable -ParameterFilter { $message -eq $VerboseMessage1}
+
+
+       It "Passes the Functional Mock" {
            New-FunctionPesterTest -Function Export-Function -OutPath C:\TextFile\PTest\ | Should -Be "Export-Function"
            Assert-MockCalled -CommandName New-FunctionPesterTest -Times 1
-           
+
        }
-       
+
        It "Creates the required Objects" {
        New-Object -TypeName System.Text.StringBuilder | Should -Be "SB"
        New-Object -TypeName System.Collections.ArrayList | Should -Be "ArrayList"
        Assert-MockCalled -CommandName New-Object -Times 2
        }
-       
+
        It "Creates the Export-Function Pester Test File" {
 
        New-Item -Path $tests -ItemType "File" -Force | Should -Be "Export-Function.Test.ps1"
        Assert-MockCalled -CommandName New-Item -Times 1
-       
+
        }
-       
+
        It "Sets Content of the Export-Function Pester Test File" {
 
        Set-Content -Path $tests -Value $ExpectedValue | Should -Be "Export-Function.Test.ps1"
        Assert-MockCalled -CommandName Set-Content -Times 1 -Scope It
-       
+
        }
 
        It "Mocked Out-Null" {
 
-       Out-Null | Should -BeNullOrEmpty 
+       Out-Null | Should -BeNullOrEmpty
        Assert-MockCalled -CommandName Out-Null -Times 1
        }
-       
+
 
        It "Mocked Write-Verbose" {
 
@@ -94,8 +94,5 @@ It 'Has a parameter called OutPath' {
 
        It "Mocked everything correctly" { Assert-VerifiableMock }
 
-       
 
-}    
-
-
+}

--- a/Public/New/Tests/New-FunctionPesterTest.Tests.ps1
+++ b/Public/New/Tests/New-FunctionPesterTest.Tests.ps1
@@ -3,153 +3,153 @@
    Context 'Parameters for New-FunctionPesterTest'{
 
         It 'Has a Parameter called Function' {
-            $Function.Parameters.Keys.Contains('Function') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('Function') | Should -Be 'True'
             }
         It 'Function Parameter is Identified as Mandatory being True True' {
-            [String]$Function.Parameters.Function.Attributes.Mandatory | Should be 'True True'
+            [String]$Function.Parameters.Function.Attributes.Mandatory | Should -Be 'True True'
             }
         It 'Function Parameter is of String Type' {
-            $Function.Parameters.Function.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.Function.ParameterType.FullName | Should -Be 'System.String'
             }
         It 'Function Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.Function.ParameterSets.Keys | Should Be 'Passthru Basic'
+            [String]$Function.Parameters.Function.ParameterSets.Keys | Should -Be 'Passthru Basic'
             }
         It 'Function Parameter Position is defined correctly' {
-            [String]$Function.Parameters.Function.Attributes.Position | Should be '-2147483648 -2147483648'
+            [String]$Function.Parameters.Function.Attributes.Position | Should -Be '-2147483648 -2147483648'
             }
         It 'Does Function Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.Function.Attributes.ValueFromPipeline | Should be 'False False'
+            [String]$Function.Parameters.Function.Attributes.ValueFromPipeline | Should -Be 'False False'
             }
         It 'Does Function Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.Function.Attributes.ValueFromPipelineByPropertyName | Should be 'False False'
+            [String]$Function.Parameters.Function.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False False'
             }
         It 'Does Function Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.Function.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for Function '{
-            $function.Definition.Contains('.PARAMETER Function') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER Function') | Should -Be 'True'
             }
         It 'Has a Parameter called ResolvedFunction' {
-            $Function.Parameters.Keys.Contains('ResolvedFunction') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('ResolvedFunction') | Should -Be 'True'
             }
         It 'ResolvedFunction Parameter is Identified as Mandatory being True' {
-            [String]$Function.Parameters.ResolvedFunction.Attributes.Mandatory | Should be 'True'
+            [String]$Function.Parameters.ResolvedFunction.Attributes.Mandatory | Should -Be 'True'
             }
         It 'ResolvedFunction Parameter is of Object Type' {
-            $Function.Parameters.ResolvedFunction.ParameterType.FullName | Should be 'System.Object'
+            $Function.Parameters.ResolvedFunction.ParameterType.FullName | Should -Be 'System.Object'
             }
         It 'ResolvedFunction Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.ResolvedFunction.ParameterSets.Keys | Should Be 'Passthru'
+            [String]$Function.Parameters.ResolvedFunction.ParameterSets.Keys | Should -Be 'Passthru'
             }
         It 'ResolvedFunction Parameter Position is defined correctly' {
-            [String]$Function.Parameters.ResolvedFunction.Attributes.Position | Should be '-2147483648'
+            [String]$Function.Parameters.ResolvedFunction.Attributes.Position | Should -Be '-2147483648'
             }
         It 'Does ResolvedFunction Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.ResolvedFunction.Attributes.ValueFromPipeline | Should be 'False'
+            [String]$Function.Parameters.ResolvedFunction.Attributes.ValueFromPipeline | Should -Be 'False'
             }
         It 'Does ResolvedFunction Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.ResolvedFunction.Attributes.ValueFromPipelineByPropertyName | Should be 'False'
+            [String]$Function.Parameters.ResolvedFunction.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False'
             }
         It 'Does ResolvedFunction Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.ResolvedFunction.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for ResolvedFunction '{
-            $function.Definition.Contains('.PARAMETER ResolvedFunction') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER ResolvedFunction') | Should -Be 'True'
             }
         It 'Has a Parameter called OutPath' {
-            $Function.Parameters.Keys.Contains('OutPath') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('OutPath') | Should -Be 'True'
             }
         It 'OutPath Parameter is Identified as Mandatory being True True' {
-            [String]$Function.Parameters.OutPath.Attributes.Mandatory | Should be 'True True'
+            [String]$Function.Parameters.OutPath.Attributes.Mandatory | Should -Be 'True True'
             }
         It 'OutPath Parameter is of String Type' {
-            $Function.Parameters.OutPath.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.OutPath.ParameterType.FullName | Should -Be 'System.String'
             }
         It 'OutPath Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.OutPath.ParameterSets.Keys | Should Be 'Passthru Basic'
+            [String]$Function.Parameters.OutPath.ParameterSets.Keys | Should -Be 'Passthru Basic'
             }
         It 'OutPath Parameter Position is defined correctly' {
-            [String]$Function.Parameters.OutPath.Attributes.Position | Should be '-2147483648 -2147483648'
+            [String]$Function.Parameters.OutPath.Attributes.Position | Should -Be '-2147483648 -2147483648'
             }
         It 'Does OutPath Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipeline | Should be 'False False'
+            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipeline | Should -Be 'False False'
             }
         It 'Does OutPath Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipelineByPropertyName | Should be 'False False'
+            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False False'
             }
         It 'Does OutPath Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for OutPath '{
-            $function.Definition.Contains('.PARAMETER OutPath') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER OutPath') | Should -Be 'True'
             }
         It 'Has a Parameter called PrivateFunction' {
-            $Function.Parameters.Keys.Contains('PrivateFunction') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('PrivateFunction') | Should -Be 'True'
             }
         It 'PrivateFunction Parameter is Identified as Mandatory being False' {
-            [String]$Function.Parameters.PrivateFunction.Attributes.Mandatory | Should be 'False'
+            [String]$Function.Parameters.PrivateFunction.Attributes.Mandatory | Should -Be 'False'
             }
         It 'PrivateFunction Parameter is of SwitchParameter Type' {
-            $Function.Parameters.PrivateFunction.ParameterType.FullName | Should be 'System.Management.Automation.SwitchParameter'
+            $Function.Parameters.PrivateFunction.ParameterType.FullName | Should -Be 'System.Management.Automation.SwitchParameter'
             }
         It 'PrivateFunction Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.PrivateFunction.ParameterSets.Keys | Should Be 'Passthru'
+            [String]$Function.Parameters.PrivateFunction.ParameterSets.Keys | Should -Be 'Passthru'
             }
         It 'PrivateFunction Parameter Position is defined correctly' {
-            [String]$Function.Parameters.PrivateFunction.Attributes.Position | Should be '-2147483648'
+            [String]$Function.Parameters.PrivateFunction.Attributes.Position | Should -Be '-2147483648'
             }
         It 'Does PrivateFunction Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.PrivateFunction.Attributes.ValueFromPipeline | Should be 'False'
+            [String]$Function.Parameters.PrivateFunction.Attributes.ValueFromPipeline | Should -Be 'False'
             }
         It 'Does PrivateFunction Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.PrivateFunction.Attributes.ValueFromPipelineByPropertyName | Should be 'False'
+            [String]$Function.Parameters.PrivateFunction.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False'
             }
         It 'Does PrivateFunction Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.PrivateFunction.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for PrivateFunction '{
-            $function.Definition.Contains('.PARAMETER PrivateFunction') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER PrivateFunction') | Should -Be 'True'
             }
     }
     Context "Function $($function.Name) - Help Section" {
 
             It "Function $($function.Name) Has show-help comment block" {
 
-                $function.Definition.Contains('<#') | should be 'True'
-                $function.Definition.Contains('#>') | should be 'True'
+                $function.Definition.Contains('<#') | Should -Be 'True'
+                $function.Definition.Contains('#>') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Has show-help comment block has a.SYNOPSIS" {
 
-                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | should be 'True'
+                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | Should -Be 'True'
 
             }
 
             It "Function $($function.Name) Has show-help comment block has an example" {
 
-                $function.Definition.Contains('.EXAMPLE') | should be 'True'
+                $function.Definition.Contains('.EXAMPLE') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Is an advanced function" {
 
-                $function.CmdletBinding | should be 'True'
-                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | should be 'True'
+                $function.CmdletBinding | Should -Be 'True'
+                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
     
     }

--- a/Public/New/Tests/New-FunctionPesterTest.Tests.ps1
+++ b/Public/New/Tests/New-FunctionPesterTest.Tests.ps1
@@ -151,7 +151,7 @@
                 $function.CmdletBinding | Should -Be 'True'
                 $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
-    
+
     }
 
  }

--- a/Public/New/Tests/New-ModulePesterTest.Tests.ps1
+++ b/Public/New/Tests/New-ModulePesterTest.Tests.ps1
@@ -89,7 +89,7 @@
                 $function.CmdletBinding | Should -Be 'True'
                 $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
-    
+
     }
 
  }

--- a/Public/New/Tests/New-ModulePesterTest.Tests.ps1
+++ b/Public/New/Tests/New-ModulePesterTest.Tests.ps1
@@ -3,91 +3,91 @@
    Context 'Parameters for New-ModulePesterTest'{
 
         It 'Has a Parameter called ModuleName' {
-            $Function.Parameters.Keys.Contains('ModuleName') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('ModuleName') | Should -Be 'True'
             }
         It 'ModuleName Parameter is Identified as Mandatory being False' {
-            [String]$Function.Parameters.ModuleName.Attributes.Mandatory | Should be 'False'
+            [String]$Function.Parameters.ModuleName.Attributes.Mandatory | Should -Be 'False'
             }
         It 'ModuleName Parameter is of String Type' {
-            $Function.Parameters.ModuleName.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.ModuleName.ParameterType.FullName | Should -Be 'System.String'
             }
         It 'ModuleName Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.ModuleName.ParameterSets.Keys | Should Be '__AllParameterSets'
+            [String]$Function.Parameters.ModuleName.ParameterSets.Keys | Should -Be '__AllParameterSets'
             }
         It 'ModuleName Parameter Position is defined correctly' {
-            [String]$Function.Parameters.ModuleName.Attributes.Position | Should be '0'
+            [String]$Function.Parameters.ModuleName.Attributes.Position | Should -Be '0'
             }
         It 'Does ModuleName Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.ModuleName.Attributes.ValueFromPipeline | Should be 'False'
+            [String]$Function.Parameters.ModuleName.Attributes.ValueFromPipeline | Should -Be 'False'
             }
         It 'Does ModuleName Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.ModuleName.Attributes.ValueFromPipelineByPropertyName | Should be 'False'
+            [String]$Function.Parameters.ModuleName.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False'
             }
         It 'Does ModuleName Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.ModuleName.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for ModuleName '{
-            $function.Definition.Contains('.PARAMETER ModuleName') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER ModuleName') | Should -Be 'True'
             }
         It 'Has a Parameter called OutPath' {
-            $Function.Parameters.Keys.Contains('OutPath') | Should Be 'True'
+            $Function.Parameters.Keys.Contains('OutPath') | Should -Be 'True'
             }
         It 'OutPath Parameter is Identified as Mandatory being False' {
-            [String]$Function.Parameters.OutPath.Attributes.Mandatory | Should be 'False'
+            [String]$Function.Parameters.OutPath.Attributes.Mandatory | Should -Be 'False'
             }
         It 'OutPath Parameter is of String Type' {
-            $Function.Parameters.OutPath.ParameterType.FullName | Should be 'System.String'
+            $Function.Parameters.OutPath.ParameterType.FullName | Should -Be 'System.String'
             }
         It 'OutPath Parameter is member of ParameterSets' {
-            [String]$Function.Parameters.OutPath.ParameterSets.Keys | Should Be '__AllParameterSets'
+            [String]$Function.Parameters.OutPath.ParameterSets.Keys | Should -Be '__AllParameterSets'
             }
         It 'OutPath Parameter Position is defined correctly' {
-            [String]$Function.Parameters.OutPath.Attributes.Position | Should be '1'
+            [String]$Function.Parameters.OutPath.Attributes.Position | Should -Be '1'
             }
         It 'Does OutPath Parameter Accept Pipeline Input?' {
-            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipeline | Should be 'False'
+            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipeline | Should -Be 'False'
             }
         It 'Does OutPath Parameter Accept Pipeline Input by PropertyName?' {
-            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipelineByPropertyName | Should be 'False'
+            [String]$Function.Parameters.OutPath.Attributes.ValueFromPipelineByPropertyName | Should -Be 'False'
             }
         It 'Does OutPath Parameter use advanced parameter Validation? ' {
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateScript' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should Be 'False'
-            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullOrEmptyAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateNotNullAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateScript' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidateRangeAttribute' | Should -Be 'False'
+            $Function.Parameters.OutPath.Attributes.TypeID.Name -contains 'ValidatePatternAttribute' | Should -Be 'False'
             }
         It 'Has Parameter Help Text for OutPath '{
-            $function.Definition.Contains('.PARAMETER OutPath') | Should Be 'True'
+            $function.Definition.Contains('.PARAMETER OutPath') | Should -Be 'True'
             }
     }
     Context "Function $($function.Name) - Help Section" {
 
             It "Function $($function.Name) Has show-help comment block" {
 
-                $function.Definition.Contains('<#') | should be 'True'
-                $function.Definition.Contains('#>') | should be 'True'
+                $function.Definition.Contains('<#') | Should -Be 'True'
+                $function.Definition.Contains('#>') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Has show-help comment block has a.SYNOPSIS" {
 
-                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | should be 'True'
+                $function.Definition.Contains('.SYNOPSIS') -or $function.Definition.Contains('.Synopsis') | Should -Be 'True'
 
             }
 
             It "Function $($function.Name) Has show-help comment block has an example" {
 
-                $function.Definition.Contains('.EXAMPLE') | should be 'True'
+                $function.Definition.Contains('.EXAMPLE') | Should -Be 'True'
             }
 
             It "Function $($function.Name) Is an advanced function" {
 
-                $function.CmdletBinding | should be 'True'
-                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | should be 'True'
+                $function.CmdletBinding | Should -Be 'True'
+                $function.Definition.Contains('param') -or  $function.Definition.Contains('Param') | Should -Be 'True'
             }
     
     }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PesterHelpers has the following functions
 * Export-Function
 * New-ModulePesterTest
 
-PesterHelpers has the following dependancy
+PesterHelpers has the following dependency
 
 * PSScriptAnalyzer - Tested with v 1.4.0 though should work with prior versions as well.
 
@@ -17,7 +17,7 @@ An example of this working in a PowerShell v2/v3 environment would be the follow
 ```powershell
 Get-Command -Module SPCSPS | Where-Object {$_.CommandType -eq 'Function'}  | ForEach-Object { Export-Function -Function $_.Name -OutPath C:\TextFile\SPCSPS\ }
 ```
-Though in PowerShell v4/5 we can also do the following for an extra added perfomance boost
+Though in PowerShell v4/5 we can also do the following for an extra added performance boost
 ```powershell
 (Get-Command -Module SPCSPS).Where{$_.CommandType -eq 'Function'}.Foreach{Export-Function -Function $_.Name -OutPath C:\TextFile\SPCSPS\}
 ```
@@ -25,12 +25,11 @@ This will get all the Functions from the module SPCSPS and export the Function D
 
 This does require that the module is either loaded into memory or is located in a $env:PSModulePath location.
 
-The New-ModulePesterTest function can be used in the below manner 
+The New-ModulePesterTest function can be used in the below manner
 ```powershell
 New-ModulePesterTest -ModuleName SPCSPS
 ```
-This will grab the Module Path from the module and create a basic Pester Test for the Module in that Folder - note that for modules installed via PowerShell Gallery or are in the ProgramFiles\WindowsPowerShell\Modules\ location this will need to be run in an elevated session. This is predominiantly for those modules that you have previously written and struggle to find the time to write any tests for and is quite comprehensive in its use of the PowerShell ScriptAnalyzer to buid a number of tests.
-
+This will grab the Module Path from the module and create a basic Pester Test for the Module in that Folder - note that for modules installed via PowerShell Gallery or are in the ProgramFiles\WindowsPowerShell\Modules\ location this will need to be run in an elevated session. This is predominantly for those modules that you have previously written and struggle to find the time to write any tests for and is quite comprehensive in its use of the PowerShell ScriptAnalyzer to build a number of tests.
 
 To Install the Module and if you are running PowerShell v5 then just run the below
 ```powershell


### PR DESCRIPTION
I updated the following:
- `Should Be` to `Should -Be`
- Removed a ton of whitespace that was causing Script Analyzer failures
- Removed the whitespace that was included in new function test that caused Script Analyzer failure on new tests
- Updated the doc and fixed a few minor typos.

Note: I looked at moving all the way to Pester 5, but there is too much to change. I tested it all in Pester 4.7.3 and it works. This project really helped get me going in Pester, I'd hate to see it die.